### PR TITLE
Issue #11 - Modify djongo.model to django.db.model

### DIFF
--- a/user/models.py
+++ b/user/models.py
@@ -1,11 +1,16 @@
-from djongo import models
-from djongo.models import DjongoManager
-from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
+
+from django.db import models
+
+from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+# from djongo import models
+# from djongo.models import DjongoManager
+# class UserManager(DjongoManager):
 
-class UserManager(DjongoManager):
+
+class UserManager(BaseUserManager):
     use_in_migrations = True
 
     # Email 중복 확인 메서드


### PR DESCRIPTION
https://github.com/milideal/MiliDeal/issues/11
djongo를 사용할 때 `'super' object has no attribute '__getattr__' ` 이 뜨는 것을 확인했습니다.
djongo.model 에서 django.db.model 으로 변경 완료했습니다.
```
# 'dj_rest_auth.urls' 를 추가했으므로 아래와 같이 사용할 수 있습니다.

# 비밀 번호 리셋
# user/auth/password/reset/ [name='rest_password_reset']                    => 작동 X 확인 필요
# user/auth/password/reset/confirm/ [name= 'rest_password_reset_confirm']    => 작동 O, reset 은 확인 중

# user/auth/login/ [name= 'rest_login']                                     => 작동 O
# user/auth/logout/ [name= 'rest_logout ']                                  => 작동 O
# user/auth/user/ [name= 'rest_user_details']                               => 작동 O

# 비밀 번호 변경, 로그인 된 상태 에서 가능
# user/auth/password/change/ [name='rest_password_change']                  => 작동 O

# 유효한 토큰 인지 확인 (refresh, access 둘 다 됨)
# user/auth/token/verify/ [name='token_verify']                             => 작동 O

# refresh 토큰을 이용 하여 access 토큰 재발급
# user/auth/token/refresh/ [name='token_refresh']                           => 작동 O
```
위에 보시는 것 처럼, 테스트를 완료했습니다.

비밀번호 리셋은 dj-rest-auth와 allauth 코드를 보니, 뷰와 시리얼라이즈 오버라이딩으로 해결하기 어려워 보입니다.
플로우는 아래와 같습니다.
1. 이메일이 있는지 확인 (여기서 sql에러가 발생합니다. create에서도 같은 문제가 발생하였으나, reset의 경우 내부 구조가 달라 어려워보입니다.)
2. 이메일이 있다면, 유저에게 이메일 발송
  ```
opts = {
            'use_https': request.is_secure(),
            'from_email': getattr(settings, 'DEFAULT_FROM_EMAIL'),
            'request': request,
            'token_generator': default_token_generator,
        }
 ```
토큰이 포함되어, reset/confirm에서 승인 시 필요합니다.
3. 토큰이 맞다면, 리셋 실행.

대안으로 운영자에게 메일을 보내어 비밀번호 리셋을 하는 방법이 있습니다.